### PR TITLE
Bugfix empty channel

### DIFF
--- a/mchplnet/services/scope.py
+++ b/mchplnet/services/scope.py
@@ -117,11 +117,15 @@ class ScopeSetup:
 
         Args:
             channel_name (str): The name of the channel to be removed.
+
+        Returns:
+            int: the total number of channels after removal
         """
         if channel_name in self.channels:
             self.channels.pop(channel_name)
-            if self.scope_trigger.channel.name == channel_name:
+            if self.scope_trigger.channel and self.scope_trigger.channel.name == channel_name:
                 self.reset_trigger()
+        return len(self.channels)
 
     def get_channel(self, channel_name: str):
         """

--- a/mchplnet/services/scope.py
+++ b/mchplnet/services/scope.py
@@ -111,7 +111,7 @@ class ScopeSetup:
             self.scope_trigger.channel = channel
         return len(self.channels)
 
-    def remove_channel(self, channel_name: str):
+    def remove_channel(self, channel_name: str) -> int:
         """
         Remove a channel from the scope configuration.
 


### PR DESCRIPTION
bug fix for channel reset

when removing a channel from the scope channel, and the channel is the last one, the channel is None and generates an Exception